### PR TITLE
Update queries to utilize first to grab student

### DIFF
--- a/vagrant/teacherActions.py
+++ b/vagrant/teacherActions.py
@@ -47,8 +47,8 @@ def db_init(self, conn_string):
         return customer_list
         '''
 
-def assignGoal(name, assignedGoal):
-    editedStudent = session.query(Student).filter(Student.name == name)
+def assignGoal(name, assignedGoal, session):
+    editedStudent = session.query(Student).filter(Student.name == name).first()
     editedStudent.goal = assignedGoal
     session.add(editedStudent)
     session.commit()

--- a/vagrant/testing.py
+++ b/vagrant/testing.py
@@ -17,9 +17,7 @@ DBSession = sessionmaker(bind=engine)
 session1 = DBSession()
 dal = Student()
 
-def getStudent(goal, session):
-    wantedStudent = session.query(Student).filter(Student.goal == goal)
-    return wantedStudent.name
+
 TEST_DB = 'testing.db'
 class TestApp(unittest.TestCase):
     # executed prior to each test
@@ -36,18 +34,22 @@ class TestApp(unittest.TestCase):
         pass
 
 
+    def getStudent(self, goal, session):
+        wantedStudent = session.query(Student).filter(Student.goal == goal).first()
+        return wantedStudent.name
+        
     def test_main_page(self):
         response = self.app.get('/', follow_redirects=True)
         self.assertEqual(response.status_code, 200)
 
     def test_CreatingStudent(self):
         testStudent = makeStudent("test name", "yeet on me", session1)
-        grab = getStudent("yeet on me", session1)
-        self.assertEqual(testStudent.name, getStudent("yeet on me"))
+        grab = self.getStudent("yeet on me", session1)
+        self.assertEqual(testStudent.name, grab)
 
     def test_editGoal(self):
         testStudent2 = makeStudent("test name", " ", session1)
-        assignGoal("test name", "test goal")
+        assignGoal("test name", "test goal", session1)
         self.assertEqual("test goal", testStudent2.goal)
 
 


### PR DESCRIPTION
You need to use first() or one_or_none() to actually grab a student out 
of the query. Failure to do so will result in an error if you try to 
perform non-query operations with that object.